### PR TITLE
Add jira subdirectory to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,9 @@
 		{
 			"matches": [
 				"http://*/browse/*",
-				"https://*/browse/*"
+				"https://*/browse/*",
+				"http://*/jira/browse/*",
+				"https://*/jira/browse/*"
 			],
 			"css": ["css/content.css"],
 			"js": ["js/zepto.min.js", "js/content.js"]


### PR DESCRIPTION
This allows the "Send to OmniFocus" button to appear when JIRA is in a "jira" subdirectory.
